### PR TITLE
Added in a temporary fix to make sure the banner only shows once

### DIFF
--- a/src/components/Confirmation/index.js
+++ b/src/components/Confirmation/index.js
@@ -6,18 +6,35 @@ import AddToCalendar from 'react-add-to-calendar';
 import ConfirmationBanner from '../ConfirmationBanner';
 
 class Confirmation extends Component {
-  state = {
-    title: "Birthday Blooms",
-    description: 'This bright arrangement is perfect as a great party centerpiece or to send to a loved one far away.',
-    location: '7033 N Moselle Ave, Chicago, IL 60646',
-    startTime: new Date('2019-04-21T10:00:00-05:00'),
-    endTime: new Date('2019-04-21T12:00:00-05:00'),
-    currency: "$",
-    originalValue: 35,
-    purchaseValue: 0,
-    originalDate: new Date('2019-04-16'),
-    numberOfFlowers: 50,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      title: "Birthday Blooms",
+      description: 'This bright arrangement is perfect as a great party centerpiece or to send to a loved one far away.',
+      location: '7033 N Moselle Ave, Chicago, IL 60646',
+      startTime: new Date('2019-04-21T10:00:00-05:00'),
+      endTime: new Date('2019-04-21T12:00:00-05:00'),
+      currency: "$",
+      originalValue: 35,
+      purchaseValue: 0,
+      originalDate: new Date('2019-04-16'),
+      numberOfFlowers: 50,
+      showBanner: true
+    };
+  }
+
+  componentWillMount = () => {
+    if (localStorage.getItem('showBanner') && this.state.showBanner) {
+      this.setState({'showBanner': false})
+    }
+  }
+
+  componentDidMount = () => {
+    if (!localStorage.getItem('showBanner')) {
+      localStorage.setItem('showBanner', 'False');
+    }
+  }
+
   render() {
     let google_link = "https://www.google.com/maps/search/?api=1&query=" + this.state.location.replace(/ /g, "+");
     let event = {
@@ -29,7 +46,7 @@ class Confirmation extends Component {
     };
     return (
       <div>
-        <ConfirmationBanner />
+        {this.state.showBanner && <ConfirmationBanner />}
         <div className="confirmation">
           <h1>Your Order</h1>
           <img src={staticImage} alt="staticImage"/>

--- a/src/components/HomePage/HomePage.js
+++ b/src/components/HomePage/HomePage.js
@@ -12,6 +12,8 @@ class HomePage extends Component {
           Click here for confirmation Page!
         </Link>
         <br/>
+        <span id="showBanner" onClick={()=>localStorage.clear()}> Click to make banner appear for confirmation page </span>
+        <br/>
         <Link to={`/sellers`} style={{textDecoration: 'none'}}>
           Click here to create a listing!
         </Link>

--- a/src/components/HomePage/style.css
+++ b/src/components/HomePage/style.css
@@ -1,0 +1,3 @@
+#showBanner:hover {
+  cursor: pointer;
+}


### PR DESCRIPTION
This was implemented using local storage. Also added an option to the homepage that will clear the local storage and allow the user to see the banner again when the go to the confirmation page.